### PR TITLE
Small fix in getObjectRotation

### DIFF
--- a/src/parameter/RenderParameter.java
+++ b/src/parameter/RenderParameter.java
@@ -185,7 +185,10 @@ public class RenderParameter implements Parameter {
 	}
 
 	public Quaternion getObjectRotation() {
-		return new Quaternion().fromAngles(OBJECT_ROTATION_X, OBJECT_ROTATION_Y, OBJECT_ROTATION_Z);
+		float[] angles = new float[] { (float) matrix.getQuick(OBJECT_ROTATION_X),
+									(float) matrix.getQuick(OBJECT_ROTATION_Y),
+									(float) matrix.getQuick(OBJECT_ROTATION_Z) };
+		return new Quaternion().fromAngles(angles);
 	}
 
 	public void setObjectRotation(Quaternion objectRotation) {


### PR DESCRIPTION
Fixed a small bug in getObjectRotation which caused the Object Rotation fail to respond in EditorApp and FittingApp.
